### PR TITLE
Define BRANCH envvar and guard against unset envvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ The Template to deploy the JumpBox assumes that the Key-Vault is in the Same sub
 #### create the KeyVault
 
 ```bash
-AZURE_VAULT=<your vaultname, name must be unique fro AZURE_VAULT.vault.azure.com>
+set -u
+AZURE_VAULT=<your vaultname, name must be unique for AZURE_VAULT.vault.azure.com>
 VAULT_RG=<your Vault Resource Group>
 LOCATION=<azure location, e.g. westus, westeurope>
 ## Create RG to set your KeyVault
@@ -81,6 +82,7 @@ ENV_NAME=control
 ENV_SHORT_NAME=cckb
 CONTROLPLANE_DOMAIN_NAME=<your domain, e.g. domain.com>
 CONTROLPLANE_SUBDOMAIN_NAME=<your subdomain for control plane, e.g.control>
+BRANCH=master # the version of controlplane-jump-azure to use
 ```
 
 you might also add some optional Parameters to override default values:


### PR DESCRIPTION
The BRANCH envvar is used, but not defined. This commit defines it explicitly as an input var from the users .env file.

We've also added a `set -u` so that problems like this are more obvious.