### PR TITLE
Fix the delete-time envvars reference to the RG created for the Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ use this to delete the keyvault policy and remove all deployed resources
 ```bash
 az keyvault delete-policy --name ${AZURE_VAULT} --object-id $(az vm identity show --resource-group ${JUMPBOX_RG} --name controlplanejumphost --query principalId --output tsv)
 az group delete --name ${JUMPBOX_RG} --yes
-az group delete --name ${ENV_NAME} --yes
+az group delete --name ${VAULT_RG} --yes
 ssh-keygen -R "${JUMPBOX_NAME}.${AZURE_REGION}.cloudapp.azure.com"
 ```
 


### PR DESCRIPTION
The 2 Resource Groups created are named `$JUMPBOX_RG` and `$VAULT_RG`, but the delete script refers to `ENV_NAME` instead of the latter.

This commit fixes the problem by referring to `VAULT_RG`.